### PR TITLE
Supporting ROS Melodic and Gazebo 9

### DIFF
--- a/simulation_ws/src/deepracer_interpreter/src/racecar_plugin.hh
+++ b/simulation_ws/src/deepracer_interpreter/src/racecar_plugin.hh
@@ -8,12 +8,17 @@
 
 #include <gazebo/common/common.hh>
 #include <gazebo/gazebo.hh>
-#include <gazebo/math/Vector3.hh>
 #include <gazebo/physics/physics.hh>
 #include <ignition/math/Vector3.hh>
 
 #include "ros/ros.h"
 #include "deepracer_msgs/Progress.h"
+
+#if GAZEBO_MAJOR_VERSION >= 9
+#include <ignition/math/Pose3.hh>
+#else
+#include <gazebo/math/Vector3.hh>
+#endif
 
 namespace gazebo
 {
@@ -25,7 +30,11 @@ class RacecarPlugin : public ModelPlugin
                     const double progrezz, const double distanceFromCenter, const double distanceFromBorder1,
                     const double distanceFromBorder2);
 
+#if GAZEBO_MAJOR_VERSION >= 9
+  ignition::math::Vector3<double> getCarPosition(const ignition::math::Pose3<double> pose);
+#else
   gazebo::math::Vector3 getCarPosition(const gazebo::math::Pose pose);
+#endif
 
   void OnUpdate();
 
@@ -59,7 +68,12 @@ private:
   int MAX_POLYGON_VERTEX = 100;
   double MAX_VALUE = 9999999;
   double EPSILON = 1e-6;
+
+#if GAZEBO_MAJOR_VERSION >= 9
+  ignition::math::Vector3<double> RELATIVE_POSITION_OF_FRONT_OF_CAR = ignition::math::Vector3<double>(0.25, 0, 0);
+#else
   gazebo::math::Vector3 RELATIVE_POSITION_OF_FRONT_OF_CAR = gazebo::math::Vector3(0.25, 0, 0);
+#endif
 
   double vertices[100][2];
   double numberOfVertices = 0;

--- a/simulation_ws/src/sagemaker_rl_agent/setup.py
+++ b/simulation_ws/src/sagemaker_rl_agent/setup.py
@@ -21,7 +21,7 @@ setup(
         'pandas==0.20.2',
         'Pillow==4.3.0',
         'pygame==1.9.3',
-        'PyYAML==3.13',
+        'PyYAML==4.2b1',
         'redis==2.10.6',
         'rospkg==1.1.7',
         'scipy==0.19.0',


### PR DESCRIPTION
*Description of changes:*
Enable Racecar plugin to run in both Gazebo 7 and 9.
Also enable usage of both ROS Kinetic and Melodic.