### PR TITLE
Updates setup.py to explicitly set zip_safe

### DIFF
--- a/simulation_ws/src/sagemaker_rl_agent/setup.py
+++ b/simulation_ws/src/sagemaker_rl_agent/setup.py
@@ -9,6 +9,7 @@ REQUIRES_PYTHON = '>=3.5.0'
 setup(
     name=NAME,
     version='0.0.1',
+    zip_safe=False,
     packages=find_packages(),
     python_requires=REQUIRES_PYTHON,
     install_requires=[


### PR DESCRIPTION
When building under Ubuntu 16.04 locally, I found I wasn't able to build  sagemaker_rl_agent as the error outputted 
```
zip_safe flat not set....
markov.single_machine_training_worker.py module references __file__
```
Python egg bundle automatically analyze bundles to see if they can be deployed as a zip, because markov can't, it throws an error at me. Updating the setup.py to set the `zip_safe` flag to `False` it builds.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
