### PR TITLE
Remove setup-file element from simulation_ws/.rosinstall

### DIFF
--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,3 +1,1 @@
-# kinetic.rosinstall
-- setup-file: {local-name: /opt/ros/kinetic/setup.sh}
 


### PR DESCRIPTION
Not needed and will just confuse customers as we also support Melodic.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
