### PR TITLE
Remove version defaults in roboMakerSettings.json

### DIFF
--- a/roboMakerSettings.json
+++ b/roboMakerSettings.json
@@ -37,12 +37,12 @@
             }
           },
           "robotSoftwareSuite": {
-            "version": "Kinetic",
+            "version": "<capitalised name of ROS distribution, e.g. Kinetic>",
             "name": "ROS"
           },
           "simulationSoftwareSuite": {
             "name": "Gazebo",
-            "version": "7"
+            "version": "<gazebo version number, e.g. 7>"
           },
           "renderingEngine": {
             "name": "OGRE",
@@ -83,12 +83,12 @@
             }
           },
           "robotSoftwareSuite": {
-            "version": "Kinetic",
+            "version": "<capitalised name of ROS distribution, e.g. Kinetic>",
             "name": "ROS"
           },
           "simulationSoftwareSuite": {
             "name": "Gazebo",
-            "version": "7"
+            "version": "<gazebo version number, e.g. 7>"
           },
           "renderingEngine": {
             "name": "OGRE",


### PR DESCRIPTION
Prepopulating the json with specific versions (like Kinetic, Gazebo7) could lead to customer confusion, e.g. if they choose to use a Melodic dev environment in C9. This change removes those defaults.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
